### PR TITLE
Fix -y|--year option type handling

### DIFF
--- a/bin/aoc-downloader
+++ b/bin/aoc-downloader
@@ -33,7 +33,7 @@ foreach ($autoloadPaths as $path) {
         $downloader = new Downloader($input->getArgument('session_id'));
         $dir        = $input->getOption('output');
 
-        if ($year = $input->getOption('year')) {
+        if ($year = (int)$input->getOption('year')) {
             $years = [$year];
         } else {
             $years = range(2015, date('Y'));

--- a/composer.json
+++ b/composer.json
@@ -50,5 +50,10 @@
         "psr-4": {
             "ColinODell\\AOCDownloader\\": "src/"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }


### PR DESCRIPTION
This PR fixes a type error when `-y` or `--year` option is used. Ideally there should be an input validation, but I tried to keep my changes to a minimum, but if that's the case, I'm happy to implement.

```
ColinODell\AOCDownloader\Downloader::getInput(): Argument #1 ($year) must be of type int,
string given, called in aoc-downloader/bin/aoc-downloader on line 52
```

The function `ColinODell\AOCDownloader\Downloader::getInput` is defined as:
```php
public function getInput(int $year, int $day): string
```

The function `Symfony\Component\Console\Input\InputInterface::getOption` is defined as:
```php
public function getOption(string $name): mixed
```
